### PR TITLE
Info SQL Database Tool - remove whitespaces in table names

### DIFF
--- a/libs/langchain/langchain/tools/sql_database/tool.py
+++ b/libs/langchain/langchain/tools/sql_database/tool.py
@@ -60,7 +60,7 @@ class InfoSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Get the schema for tables in a comma-separated list."""
-        return self.db.get_table_info_no_throw(table_names.split(", "))
+        return self.db.get_table_info_no_throw(table_names.replace(" ", "").split(","))
 
 
 class ListSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):


### PR DESCRIPTION
Remove the whitespaces in the input of the InfoSQLDatabaseTool in order to support another format of input.
for example the input "table1,table2,table2" will throw exception unless the fix.